### PR TITLE
Working Actions workflow

### DIFF
--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -26,11 +26,14 @@ jobs:
         - .:/project
       env:
         TEST_PLATFORM: ${{ matrix.platform }}
-        UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
+        # cannot use license here, leads to Unrecognized named-value: 'secrets'
+        # UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
 
     steps:
       - uses: actions/checkout@v1
       - name: before script
+        env:
+          UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
         run: ./ci/before_script.sh
       - name: test
         run: ./ci/test.sh
@@ -46,11 +49,13 @@ jobs:
         - .:/project
       env:
         BUILD_TARGET: ${{ matrix.target }}
-        UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
+        # UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
 
     steps:
       - uses: actions/checkout@v1
       - name: before script
+        env:
+          UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
         run: ./ci/before_script.sh
       - name: build
         run: ./ci/build.sh

--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -3,17 +3,17 @@ name: Build and test a unity3d project
 on: [push]
 
 jobs:
-  get_license:
-    runs-on: ubuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      volumes:
-        - .:/project
+  # get_license:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: gableroux/unity3d:2019.1.14f1
+  #     volumes:
+  #       - .:/project
 
-    steps:
-    - uses: actions/checkout@v1
-    - name: get license
-      run: ./ci/get_license.sh
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: get license
+  #     run: ./ci/get_license.sh
 
   test:
     strategy:
@@ -26,6 +26,7 @@ jobs:
         - .:/project
       env:
         TEST_PLATFORM: ${{ matrix.platform }}
+        UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
 
     steps:
       - uses: actions/checkout@v1
@@ -45,6 +46,7 @@ jobs:
         - .:/project
       env:
         BUILD_TARGET: ${{ matrix.target }}
+        UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -13,12 +13,15 @@ jobs:
     - name: get license
       run: ./ci/get_license.sh
 
-  test_editmode:
+  test:
+    strategy:
+      matrix:
+        platform: [editmode, playmode]
     runs-on: unbuntu-latest
     container:
       image: gableroux/unity3d:2019.1.14f1
       env:
-        TEST_PLATFORM: editmode
+        TEST_PLATFORM: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v1
@@ -27,62 +30,15 @@ jobs:
       - name: test
         run: ./ci/test.sh
 
-  test_playmode:
+  build:
+    strategy:
+      matrix:
+        target: [StandaloneWindows64, WebGL, StandaloneLinux64]
     runs-on: unbuntu-latest
     container:
       image: gableroux/unity3d:2019.1.14f1
       env:
-        TEST_PLATFORM: playmode
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: before script
-        run: ./ci/before_script.sh
-      - name: test
-        run: ./ci/test.sh
-
-  build_StandaloneWindows64:
-    runs-on: unbuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      env:
-        BUILD_TARGET: StandaloneWindows64
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: before script
-        run: ./ci/before_script.sh
-      - name: build
-        run: ./ci/build.sh
-      - uses: actions/upload-artifact@master
-        with:
-          name: my-artifact
-          path: ./Builds/
-
-  build_WebGL:
-    runs-on: unbuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      env:
-        BUILD_TARGET: WebGL
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: before script
-        run: ./ci/before_script.sh
-      - name: build
-        run: ./ci/build.sh
-      - uses: actions/upload-artifact@master
-        with:
-          name: my-artifact
-          path: ./Builds/
-
-  build_StandaloneLinux64:
-    runs-on: unbuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      env:
-        BUILD_TARGET: StandaloneLinux64
+        BUILD_TARGET: ${{ matrix.target }}
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -20,45 +20,38 @@ jobs:
       matrix:
         platform: [editmode, playmode]
     runs-on: ubuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      volumes:
-        - .:/project
-      env:
-        TEST_PLATFORM: ${{ matrix.platform }}
-        # cannot use license here, leads to Unrecognized named-value: 'secrets'
-        # UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
-
     steps:
       - uses: actions/checkout@v1
-      - name: before script
+      - name: Pull docker image
         env:
+          IMAGE_NAME: gableroux/unity3d:2019.1.14f1
+        run: docker pull $IMAGE_NAME
+      - name: Run tests
+        env:
+          IMAGE_NAME: gableroux/unity3d:2019.1.14f1
           UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
-        run: ./ci/before_script.sh
-      - name: test
-        run: ./ci/test.sh
+          TEST_PLATFORM: ${{ matrix.platform }}
+        run: ./ci/docker_test.sh
 
   build:
     strategy:
       matrix:
         target: [StandaloneWindows64, WebGL, StandaloneLinux64]
     runs-on: ubuntu-latest
-    container:
-      image: gableroux/unity3d:2019.1.14f1
-      volumes:
-        - .:/project
-      env:
-        BUILD_TARGET: ${{ matrix.target }}
-        # UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
 
     steps:
       - uses: actions/checkout@v1
-      - name: before script
+      - name: Pull docker image
         env:
+          IMAGE_NAME: gableroux/unity3d:2019.1.14f1
+        run: docker pull $IMAGE_NAME
+      - name: Perform build
+        env:
+          IMAGE_NAME: gableroux/unity3d:2019.1.14f1
           UNITY_LICENSE_CONTENT: ${{ secrets.UNITY_LICENSE_CONTENT }}
-        run: ./ci/before_script.sh
-      - name: build
-        run: ./ci/build.sh
+          BUILD_NAME: GithubActions
+          BUILD_TARGET: ${{ matrix.target }}
+        run: ./ci/docker_build.sh
       - uses: actions/upload-artifact@master
         with:
           name: my-artifact

--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -54,5 +54,5 @@ jobs:
         run: ./ci/docker_build.sh
       - uses: actions/upload-artifact@master
         with:
-          name: my-artifact
+          name: ${{ matrix.target }}
           path: ./Builds/

--- a/.github/workflows/unity3d.yml
+++ b/.github/workflows/unity3d.yml
@@ -4,9 +4,11 @@ on: [push]
 
 jobs:
   get_license:
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     container:
       image: gableroux/unity3d:2019.1.14f1
+      volumes:
+        - .:/project
 
     steps:
     - uses: actions/checkout@v1
@@ -17,9 +19,11 @@ jobs:
     strategy:
       matrix:
         platform: [editmode, playmode]
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     container:
       image: gableroux/unity3d:2019.1.14f1
+      volumes:
+        - .:/project
       env:
         TEST_PLATFORM: ${{ matrix.platform }}
 
@@ -34,9 +38,11 @@ jobs:
     strategy:
       matrix:
         target: [StandaloneWindows64, WebGL, StandaloneLinux64]
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     container:
       image: gableroux/unity3d:2019.1.14f1
+      volumes:
+        - .:/project
       env:
         BUILD_TARGET: ${{ matrix.target }}
 

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -5,6 +5,8 @@ set -x
 mkdir -p /root/.cache/unity3d
 mkdir -p /root/.local/share/unity3d/Unity/
 set +x
+echo 'Checking that UNITY_LICENSE_CONTENT is present'
+[[ -n "$UNITY_LICENSE_CONTENT" ]] # assert that license content is present
 echo 'Writing $UNITY_LICENSE_CONTENT to license file /root/.local/share/unity3d/Unity/Unity_lic.ulf'
 echo "$UNITY_LICENSE_CONTENT" | tr -d '\r' > /root/.local/share/unity3d/Unity/Unity_lic.ulf
 

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -12,8 +12,8 @@ set -x
 
 # Workaround for https://gitlab.com/gableroux/unity3d/issues/35
 # Prevents ALSA lib errors
-cp ci/etc/asound.conf /etc/asound.conf
+# cp ci/etc/asound.conf /etc/asound.conf
 
 # Workaround for https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/36
 # webgl build fails due to missing ffmpeg otherwise
-apt-get update && apt-get install -y ffmpeg
+# apt-get update && apt-get install -y ffmpeg


### PR DESCRIPTION
- fixed `uNbuntu-latest` typo causing permanent `Running workflow...` with gray icon
- used `strategy.matrix` to deduplicate jobs code
- switched from using `container:` to `docker_build.sh`, because for some reason Unity could not pickup license file, even though `UNITY_LICENSE_CONTENT` was passed correctly and the `.ulf` file was created successfully in `before_script.sh`
- commented out GitLab-specific workarounds; in the main example repo they should be put under `if [[ -n $SOME_GITLAB_SPECIFIC_VARIABLE ]]` check.

For some reason the WebGL build lacks all the texts in game, though the gameloop itself works fine, with sprites, music and stuff.

Feel free to squash this PR into a single commit if it fits.